### PR TITLE
VST-61377: Use Correct Validation Endpoint

### DIFF
--- a/lib/staccato/V4/tracker.rb
+++ b/lib/staccato/V4/tracker.rb
@@ -72,7 +72,10 @@ module Staccato::V4
     end
 
     def validate!
-      Staccato::Adapter::Validate.new().post_with_body(params, body)
+      Staccato::Adapter::Validate.new(
+        Staccato.default_adapter,
+        validation_uri
+      ).post_with_body(params, body)
     end
 
     def default_uri

--- a/lib/staccato/adapter/validate.rb
+++ b/lib/staccato/adapter/validate.rb
@@ -1,8 +1,15 @@
 module Staccato
   module Adapter
     class Validate
-      def initialize(adapter = Staccato.default_adapter)
-        @adapter = adapter.new URI('https://www.google-analytics.com/debug/collect')
+      def initialize(
+        adapter = Staccato.default_adapter,
+        validation_uri = universal_analytics_uri
+      )
+        @adapter = adapter.new validation_uri
+      end
+
+      def universal_analytics_uri
+        URI('https://www.google-analytics.com/debug/collect')
       end
 
       def post(params)

--- a/lib/staccato/v4.rb
+++ b/lib/staccato/v4.rb
@@ -47,7 +47,7 @@ module Staccato
 end
 
 require_relative 'option_set'
-require_relative 'v4/event'
+require_relative 'V4/event'
 
 # define tracker last so any events have dynamically defined methods
-require_relative 'v4/tracker'
+require_relative 'V4/tracker'


### PR DESCRIPTION
### Why?
The current validation method uses the old Universal Analytics Endpoint. We want be able to use the old and the new measurement protocol endpoint. This is purely for developer testing and has not impact on the current collection endpoint.

### What?
Add an optional param to pass in the new measurement protocol validation endpoint.
Address file naming issue that CircleCI is complaining about.