### PR TITLE
VST-61377: Add user_id to JSON body

### DIFF
--- a/lib/staccato/V4/tracker.rb
+++ b/lib/staccato/V4/tracker.rb
@@ -18,7 +18,7 @@ module Staccato::V4
       measurement_id,
       api_secret,
       client_id = nil,
-      user_id = nil, 
+      user_id = nil,
       options = {}
     )
       @measurement_id = measurement_id
@@ -36,6 +36,12 @@ module Staccato::V4
 
     def add_adapter(adapter)
       @adapters << adapter
+    end
+
+    # The user id for GA
+    # @return [String, nil]
+    def user_id
+      @user_id
     end
 
     # The measurement id for GA
@@ -146,7 +152,12 @@ module Staccato::V4
     attr_accessor :hit_defaults
 
     # (see Tracker#initialize)
-    def initialize(measurement_id = nil, client_id = nil, options = {})
+    def initialize(
+      measurement_id = nil,
+      client_id = nil,
+      user_id = nil,
+      options = {}
+    )
       self.events = []
     end
 
@@ -156,6 +167,10 @@ module Staccato::V4
 
     def add_adapter(*)
       []
+    end
+
+    def user_id
+      nil
     end
 
     # (see Tracker#id)

--- a/lib/staccato/V4/tracker.rb
+++ b/lib/staccato/V4/tracker.rb
@@ -12,11 +12,19 @@ module Staccato::V4
     # @param measurement_id [String] the measurement id from GA
     # @param api_secret [String] the required api secret key
     # @param client_id [String, nil] unique value to track user sessions
+    # @param user_id [String, nil] unique value to track user
     # @param options [Hash]
-    def initialize(measurement_id, api_secret, client_id = nil, options = {})
+    def initialize(
+      measurement_id,
+      api_secret,
+      client_id = nil,
+      user_id = nil, 
+      options = {}
+    )
       @measurement_id = measurement_id
       @api_secret = api_secret
       @client_id = client_id
+      @user_id = user_id
       @adapters = []
 
       self.events = []
@@ -98,7 +106,7 @@ module Staccato::V4
 
     # @private
     def body
-      Staccato::V4.encode_body(client_id, events)
+      Staccato::V4.encode_body(client_id, user_id, events)
     end
 
     # @private

--- a/lib/staccato/v4.rb
+++ b/lib/staccato/v4.rb
@@ -37,9 +37,10 @@ module Staccato
     end
 
     # JSON encode in the case of GA measurement protocol V4
-    def self.encode_body(client_id, events)
+    def self.encode_body(client_id, user_id, events)
       JSON.generate({
         client_id: client_id,
+        user_id: user_id,
         events: events
       })
     end


### PR DESCRIPTION
### Why?
We need to add a param to post with user_id in the JSON body.

Paired commit here https://github.com/vitalsource/stargate/pull/4956/commits/34cb7af6090b96c0302de442de0e93c890fbdaa5

### What?
Add user_id param to tracker and encoding.