### PR TITLE
VST-63091: Add timestamp_micros param to the tracker

### DIFF
--- a/lib/staccato/V4/tracker.rb
+++ b/lib/staccato/V4/tracker.rb
@@ -3,7 +3,7 @@ require 'staccato/adapter/validate'
 module Staccato::V4
   # The `Tracker` class has methods to create all `Hit` types
   #   using the tracker and client id
-  # 
+  #
   # @author Tony Pitale
   class Tracker
     attr_accessor :events
@@ -19,12 +19,14 @@ module Staccato::V4
       api_secret,
       client_id = nil,
       user_id = nil,
+      timestamp_micros = nil,
       options = {}
     )
       @measurement_id = measurement_id
       @api_secret = api_secret
       @client_id = client_id
       @user_id = user_id
+      @timestamp_micros = timestamp_micros
       @adapters = []
 
       self.events = []
@@ -60,6 +62,12 @@ module Staccato::V4
     # @return [String]
     def client_id
       @client_id ||= Staccato.build_client_id
+    end
+
+    # The time to associate with the event, as a Unix timestamp in
+    # microseconds.
+    def timestamp_micros
+      @timestamp_micros
     end
 
     # Add an Event instance to the events to be sent
@@ -112,7 +120,7 @@ module Staccato::V4
 
     # @private
     def body
-      Staccato::V4.encode_body(client_id, user_id, events)
+      Staccato::V4.encode_body(client_id, user_id, events, timestamp_micros)
     end
 
     # @private
@@ -156,6 +164,7 @@ module Staccato::V4
       measurement_id = nil,
       client_id = nil,
       user_id = nil,
+      timestamp_micros = nil,
       options = {}
     )
       self.events = []
@@ -170,6 +179,10 @@ module Staccato::V4
     end
 
     def user_id
+      nil
+    end
+
+    def timestamp_micros
       nil
     end
 

--- a/lib/staccato/v4.rb
+++ b/lib/staccato/v4.rb
@@ -5,7 +5,7 @@ module Staccato
     # Build a new tracker instance
     #   If the first argument is explicitly `nil`, a `NoopTracker` is returned
     #   which responds to all the same `tracker` methods but does no tracking
-    # 
+    #
     # @param measurement_id [String] the required id provided by google, i.e., `G-XXXXXXXX`
     # @param client_id [String, Integer, nil] a unique id to track the session of
     #   an individual user
@@ -37,11 +37,12 @@ module Staccato
     end
 
     # JSON encode in the case of GA measurement protocol V4
-    def self.encode_body(client_id, user_id, events)
+    def self.encode_body(client_id, user_id, events, timestamp_micros = nil)
       JSON.generate({
         client_id: client_id,
         user_id: user_id,
-        events: events
+        events: events,
+        timestamp_micros: timestamp_micros
       })
     end
   end


### PR DESCRIPTION
### What?

[VST-63091](https://vitalsource.atlassian.net/browse/VST-63091)

When GA4 channel reports build based on sessions, session revenue was all going into a bucket called unassigned. We need to pass GA `session_id`, `client_id` and `timestamp_micros` to GA for all server side events

### What Happened?

- Added `timestamp_micros` param to the tracker

**Note:** GA session_id is passed as part of the event params so no need to add that to the tracker